### PR TITLE
Add Godot validation capabilities to delivery-team plugin

### DIFF
--- a/delivery-team/skills/delivery-flow/SKILL.md
+++ b/delivery-team/skills/delivery-flow/SKILL.md
@@ -604,8 +604,8 @@ stage ran).
 Developer for engine-specific work. Game-specific testing:
 - **Headless validation**: After each story, run `godot --headless --path <project> --quit` as part of the evaluator-optimizer loop. Any new ERROR lines trigger a correction cycle.
 - **Empirical AC classification**: Classify each acceptance criterion as "structural" (verifiable by code inspection) or "empirical" (requires runtime). If empirical ACs exist and no validation tool was used, mark story as "code-complete, pending validation" rather than "done".
-- Performance profiling against frame budgets.
-- Playtest scenarios (game feel, difficulty curve, progression balance).
+- **Performance profiling**: Profile against frame budgets, memory limits, and draw call targets.
+- **Playtest scenarios**: Game feel, difficulty curve, progression balance, and player experience.
 
 ---
 

--- a/delivery-team/skills/godot/SKILL.md
+++ b/delivery-team/skills/godot/SKILL.md
@@ -28,7 +28,7 @@ Classify the request into one or more categories before proceeding:
 
 **Declare before every task:**
 
-> `Language: [GDScript | C#] | Task: [write / fix / refactor / review / explain] | References: [list of reference files used]`
+> `Language: [GDScript | C#] | Task: [write / fix / refactor / review / explain / design / validate] | References: [list of reference files used]`
 
 ---
 
@@ -104,6 +104,7 @@ Follow the official GDScript style guide and all conventions in the reference ma
 | `references/csharp-godot.md` | C# 12 / .NET 8 in Godot 4.x: partial classes, [Export], [Signal], QueueFree, nullable safety |
 | `references/scenes-nodes.md` | Scene self-containment, node type selection, hierarchy conventions, scene inheritance, Resource-based data |
 | `references/signals-architecture.md` | Signal patterns, Event Bus autoload, state machines (enum and node-based), component pattern, deferred calls |
+| `references/validation.md` | Headless validation, common agent-missed bugs, AC classification (structural vs empirical), pre-write checklist |
 
 ---
 
@@ -158,7 +159,7 @@ The sub-agent must enforce these in every output:
 - **Self-contained scenes** — scenes must work regardless of where they are placed in the tree
 - **Type everything** — all variables, parameters, and return types must be typed in GDScript
 - **No @onready access before tree entry** — never call methods that use @onready variables on a node that hasn't been added to the scene tree yet. Use `call_deferred()` or add the node first, then configure.
-- **Validate after implementation** — after every `write` or `fix` task on `.gd` or `.tscn` files, run `godot --headless --path <project> --quit` and report any new errors
+- **Validate after implementation** — if `godot` is available on PATH, run `godot --headless --path <project> --quit` after every `write` or `fix` task on `.gd` or `.tscn` files and report any new errors. If `godot` is not available, note that headless validation was skipped and recommend manual validation
 
 ---
 

--- a/delivery-team/skills/godot/references/validation.md
+++ b/delivery-team/skills/godot/references/validation.md
@@ -22,7 +22,7 @@ Loads the project, initializes all autoloads, instantiates the main scene, runs 
 ```
 godot --headless --check-only --script <script_path> 2>&1
 ```
-Parse-validates a single .gd file without loading the full project. Fast (~1s).
+Parse-validates a single .gd file without loading the full project. Fast (~1s). Requires Godot 4.2+. For earlier 4.x versions, use full project validation instead.
 
 **What it catches:**
 - Syntax errors


### PR DESCRIPTION
## Summary

Adds empirical validation capabilities to the delivery-team plugin's Godot skill, addressing #1.

### Changes
- **New reference**: `delivery-team/skills/godot/references/validation.md` — headless validation patterns, 5 common agent-missed bug patterns with detection strategies, pre-write checklist, and acceptance criteria classification (structural vs empirical)
- **Updated SKILL.md**: Added `validation` task type, `validate` sub-agent instruction, and two new architecture guardrails (@onready safety, post-implementation validation)
- **Updated delivery-flow**: Stage 6 now includes headless validation in the evaluator-optimizer loop and classifies acceptance criteria as structural vs empirical

### Problem
AI agents marked 14 stories "complete" across 4 sprints, but the Godot game was non-functional when manually tested:
- Blank screen (TileSet not rendering)
- Combat panel blocking input (broken .tscn node paths)
- Unit visuals not loading (@onready called before tree entry)
- Camera not active (missing make_current())
- Input actions corrupted by editor reformatter

### Solution
1. Teach agents to run `godot --headless` validation after implementation
2. Document the 5 most common bugs agents miss
3. Classify acceptance criteria so empirical ones aren't falsely marked "verified"
4. When empirical ACs can't be validated, mark stories "code-complete, pending validation" instead of "done"

## Test plan
- [ ] Godot skill routes to validation.md when "validate" is requested
- [ ] Sub-agent runs headless validation after write/fix tasks
- [ ] delivery-flow Stage 6 flags empirical ACs correctly
- [ ] validation.md examples match real-world failure patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)