### PR TITLE
fix(delivery-flow): stale hook migration + post-install validation (#67)

### DIFF
--- a/.delivery/config.yml
+++ b/.delivery/config.yml
@@ -81,12 +81,12 @@ monorepo:
   scope: root
 git:
   branch_strategy: github-flow
-  auto_branch: false
+  auto_branch: true
   commit_convention: conventional
   clean_tree_check: true
 github:
   create_issues: true
-  create_pr: false
+  create_pr: true
   link_commits: true
 presentation:
   default_format: structured-markdown

--- a/.delivery/memory/archive/run-2026-04-05-3d92.md
+++ b/.delivery/memory/archive/run-2026-04-05-3d92.md
@@ -1,0 +1,88 @@
+# Run Archive: run-2026-04-05-3d92
+
+**Type**: BUG_FIX | **Issue**: B-011 | **Date**: 2026-04-05 | **Status**: completed
+**Pipeline Run**: #17 | **Alias Theme**: LOTR (Aragorn facilitating)
+
+## Retrospective: Pipeline Run #17
+
+**Format:** Start / Stop / Continue (post-pipeline)
+**Facilitator:** Aragorn (Scrum Bag)
+
+*"The fellowship delivered cleanly today, and that is no small thing. Let us honour what carried us, name what held us back, and carry forward only what serves the quest."*
+
+---
+
+## Stages Executed
+
+| Stage | Depth | First-Try | DoD Rounds | Notes |
+|-------|-------|-----------|------------|-------|
+| 1. Idea | full | YES | 1 | PO triage with WSJF scoring, clean scoping |
+| 5. Plan | light | YES | 1 | QA identified 4 edge case gaps proactively |
+| 6. Dev | full | YES | 1 | All 3 stories batched into single dev pass |
+| 7. UAT | full | YES | 1 | 15/15 ACs, 23/23 TCs, 0 defects |
+
+**Skipped**: Refine, Design, Architect (BUG_FIX routing)
+**Stories**: 3/3 DONE first-try | **Defects**: 0 | **Files changed**: 1 (setup-wizard.md, +173 lines)
+
+---
+
+## Start
+
+| # | Item | Owner | Due |
+|---|------|-------|-----|
+| 1 | Track pre-pipeline config changes in the pipeline itself -- the `github.create_pr` and `git.auto_branch` config additions were made outside pipeline visibility | SM | Next pipeline run |
+| 2 | Upgrade `.delivery/config.yml` from v2.3 to v2.6 to match current schema | SM | Next session |
+
+---
+
+## Stop
+
+*Nothing to stop. The run was clean and efficient. No anti-patterns observed.*
+
+---
+
+## Continue
+
+| # | Item | Rationale |
+|---|------|-----------|
+| 1 | QA gap identification at Plan stage | 4 edge case gaps caught early, addressed proactively in Dev -- zero rework |
+| 2 | Single-file story batching in Dev | All 3 stories targeting setup-wizard.md were batched into one dev pass -- efficient and low-risk |
+| 3 | WSJF-based PO triage | Well-scoped bug fix, no scope creep, clean handoff to Plan |
+| 4 | LOTR alias theme consistency | Theme surfaced across all agents at every stage -- adds personality without friction |
+| 5 | First-try DoD passes across all stages | No self-correction rounds needed anywhere -- pre-loaded constraints and proactive gap-filling are paying off |
+
+---
+
+## Metrics
+
+| Metric | Value |
+|--------|-------|
+| Stories completed | 3/3 |
+| First-try DoD rate | 100% (4/4 stages) |
+| Defects found | 0 |
+| Defects/story rate | 0.00 |
+| Self-correction rounds | 0 |
+| Files changed | 1 |
+| Lines added | 173 |
+| Lines deleted | 0 |
+| UAT test cases | 23/23 pass |
+| Acceptance criteria | 15/15 pass |
+
+---
+
+## Action Items
+
+| # | Action | Owner | Due | Status |
+|---|--------|-------|-----|--------|
+| 1 | Upgrade config.yml v2.3 to v2.6 | SM | Next session | TODO |
+| 2 | Add pre-pipeline config changes to pipeline tracking (process improvement) | SM | Next pipeline run | TODO |
+
+---
+
+## Lessons Extracted
+
+- **Batching same-file stories**: When multiple BUG_FIX stories target the same file, batching into a single dev pass eliminates merge conflicts and reduces context-switching overhead. Continue this pattern.
+- **Proactive QA at Plan**: QA edge case gap identification at Plan stage (not just UAT) continues to drive first-try Dev passes. This is now a repeatable pattern across runs 10-17.
+- **Config drift**: Config version lagging behind schema version (v2.3 vs v2.6) is a recurring theme. Action item logged.
+
+*"And so the fellowship rests, knowing the sprint was well-fought. Two tasks remain on the road ahead -- but the path is clear, and the backlog will not fall."*

--- a/.delivery/memory/index.md
+++ b/.delivery/memory/index.md
@@ -1,7 +1,7 @@
 # Memory Index
 
-**Last updated**: 2026-04-04
-**Total runs**: 16
+**Last updated**: 2026-04-05
+**Total runs**: 17
 
 ## Stage Health (from last 5 runs)
 
@@ -12,7 +12,7 @@
 | Design | 100% (2/2) | Stable | Ran in 2 of last 5 |
 | Architect | 100% (3/3) | Stable | Ran in 3 of last 5 |
 | Plan | 80% (4/5) | **Improving** | 2 consecutive first-try passes with pre-loaded constraints |
-| Development | 60% (3/5) | Dipped | Derived artifacts corrections in w7m3 + p5v8 |
+| Development | 80% (4/5) | **Improving** | Clean first-try in 3d92; derived artifacts lesson applied proactively |
 | UAT | 100% (5/5) | Stable | 5 consecutive first-try passes |
 
 ## Hot Lessons (top 5 by impact)

--- a/delivery-team/skills/delivery-flow/references/setup-wizard.md
+++ b/delivery-team/skills/delivery-flow/references/setup-wizard.md
@@ -339,6 +339,179 @@ If `enforcement.source_code_hook` is true, the wizard installs a PreToolUse comm
 
 ---
 
+### Stale Hook Migration
+
+> **History**: Commit `0ef5070` replaced the prompt-based `enforce_pipeline_scope` hook with a command-based equivalent, but no migration logic was added. Users who installed the plugin before this change may still have the stale prompt hook in their project settings, causing conflicts where both hooks fire on Edit/Write/NotebookEdit events.
+
+The wizard runs stale hook migration during **config upgrade** or **fresh setup** (wizard execution), before hook installation. This step ensures legacy prompt-based hooks that have been superseded by command-based equivalents are detected and removed.
+
+#### When Migration Runs
+
+- On every wizard execution (fresh install, config upgrade, or re-run)
+- Before the "Project-Level Hook Installation" step installs or updates the command hook
+- After Q12 enforcement settings are confirmed but before hooks are written
+
+#### Scan Targets
+
+The wizard scans **both** settings files independently:
+
+1. **`.claude/settings.local.json`** -- User-local settings (git-ignored)
+2. **`.claude/settings.json`** -- Project-shared settings (committed)
+
+If a settings file does not exist, the wizard skips it gracefully with no error. Log: "File not found: [path] -- skipping migration scan."
+
+#### Detection Criteria
+
+For each settings file, scan the `hooks.PreToolUse` array for entries matching **all** of these conditions:
+
+- `type` is `"prompt"` (not `"command"`)
+- `matcher` includes any of: `Edit`, `Write`, or `NotebookEdit`
+
+Hooks that do **not** match these criteria are preserved untouched. For example, a prompt hook with matcher `"Bash"` is not a conflict and must not be removed.
+
+#### Removal Behavior
+
+For each stale prompt hook found:
+
+1. Remove the stale prompt hook entry from the `hooks.PreToolUse` array
+2. If a command hook for `enforce_pipeline_scope.py` already exists alongside the stale prompt hook, preserve the command hook and remove only the prompt hook
+3. If removing the stale hook leaves the `hooks.PreToolUse` array empty, remove the empty array (do not leave `"PreToolUse": []`)
+
+#### Logging
+
+For each stale hook removed, log all three fields:
+
+- **File path**: Which settings file was modified (e.g., `.claude/settings.local.json`)
+- **Matcher removed**: The matcher value of the removed hook (e.g., `"Edit|Write|NotebookEdit"`)
+- **Reason**: `"Superseded by command-based enforce_pipeline_scope.py hook"`
+
+If no stale hooks are found in either file, log: **"No stale hooks detected"** and proceed to hook installation without modification.
+
+If both files contain stale hooks, produce separate log entries for each file.
+
+#### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Settings file does not exist | Skip gracefully, log "File not found: [path]" |
+| No stale hooks in either file | Log "No stale hooks detected", proceed |
+| Stale prompt hook + command hook both present for same matcher | Remove prompt hook, preserve command hook |
+| Non-conflicting prompt hook (e.g., matcher `"Bash"`) | Preserve -- only Edit/Write/NotebookEdit matchers trigger removal |
+| Stale hook in only one of the two files | Clean that file, skip the other |
+| Multiple stale prompt hooks in one file | Remove all that match the detection criteria |
+
+---
+
+### Post-Install Hook Validation
+
+After hook installation completes (whether fresh install, migration, or re-run), the wizard validates that all expected hooks are correctly installed and no conflicts remain. This is the final verification step before the wizard announces completion.
+
+#### When Validation Runs
+
+- Immediately after the "Project-Level Hook Installation" step completes
+- After any stale hook migration has been performed
+- On every wizard execution (not skippable)
+
+#### Expected Hooks Table
+
+The wizard validates against this complete table of expected hooks. All plugin hooks come from `hooks.json`; the project-level hook comes from `.claude/settings.json`.
+
+| # | Hook Name | Event Type | Matcher | Hook Type | Command / Prompt | Timeout | Source |
+|---|-----------|------------|---------|-----------|-----------------|---------|--------|
+| 1 | Config check | SessionStart | `*` | command | `check_config.py` | 5 | hooks.json |
+| 2 | Retrospective enforcement | Stop | `*` | prompt | Retrospective completion check | 15 | hooks.json |
+| 3 | Pipeline bypass detection | PreToolUse | `Skill` | prompt | Pipeline scope check for implementation skills | 15 | hooks.json |
+| 4 | Agent prompt audit | PreToolUse | `Agent` | command | `audit_agent_prompt.py` | 10 | hooks.json |
+| 5 | GDScript validation | PostToolUse | `Write\|Edit` | command | `validate_gdscript.py` | 15 | hooks.json |
+| 6 | Skill load verification | PostToolUse | `Agent` | command | `verify_skill_load.py` | 10 | hooks.json |
+| 7 | Empirical validation | SubagentStop | `developer\|godot` | command | `flag_empirical_validation.py` | 30 | hooks.json |
+| 8 | Pipeline scope enforcement | PreToolUse | `Edit\|Write\|NotebookEdit` | command | `enforce_pipeline_scope.py` | 5 | project settings |
+
+> **Note**: Hook 8 is only expected when `enforcement.source_code_hook` is `true` in `.delivery/config.yml`. If the user chose not to install the source code hook (Q12), hook 8 is excluded from validation.
+
+#### Validation Process
+
+For each hook in the expected hooks table:
+
+1. **Locate**: Find the hook by matching event type + matcher pattern
+2. **Verify type**: Confirm the hook type matches (command vs prompt)
+3. **Verify command/prompt**: Confirm the command path or prompt content is correct
+4. **Verify timeout**: Confirm the timeout value matches
+5. **Check source**: Verify the hook exists in the correct file (hooks.json hooks are plugin-managed; hook 8 is in `.claude/settings.json`)
+
+#### Duplicate Detection
+
+After individual validation, scan for **duplicate matcher conflicts**:
+
+- Two hooks sharing the same event type AND matcher pattern but differing in hook type (one `"prompt"`, one `"command"`) constitute a conflict
+- The command-based hook takes precedence -- it is the canonical version
+- The prompt-based hook is the stale entry that should have been caught by migration
+- **Precedence rule**: Command hooks supersede prompt hooks. "Superseded" means the prompt hook was the original implementation and the command hook is the replacement that provides the same functionality with deterministic behavior
+
+#### Cleanup
+
+If duplicate detection finds stale prompt hooks that were missed by migration:
+
+1. Remove the stale prompt hook (same removal behavior as the migration step)
+2. Log the cleanup with file path, matcher, and reason
+3. Mark the hook's status as `CLEANED` in the summary
+
+#### Validation Summary
+
+Output a summary table to the user with the validation results:
+
+| Hook Name | Event Type | Matcher | Hook Type | Timeout | Status |
+|-----------|------------|---------|-----------|---------|--------|
+| Config check | SessionStart | `*` | command | 5 | PASS |
+| Retrospective enforcement | Stop | `*` | prompt | 15 | PASS |
+| Pipeline bypass detection | PreToolUse | `Skill` | prompt | 15 | PASS |
+| Agent prompt audit | PreToolUse | `Agent` | command | 10 | PASS |
+| GDScript validation | PostToolUse | `Write\|Edit` | command | 15 | PASS |
+| Skill load verification | PostToolUse | `Agent` | command | 10 | PASS |
+| Empirical validation | SubagentStop | `developer\|godot` | command | 30 | PASS |
+| Pipeline scope enforcement | PreToolUse | `Edit\|Write\|NotebookEdit` | command | 5 | PASS |
+
+**Status values**:
+
+- **PASS** -- Hook exists with correct configuration
+- **FAIL** -- Hook exists but configuration does not match expected values (wrong type, command, or timeout)
+- **MISSING** -- Hook not found in the expected location; report with full expected configuration so the user can manually install
+- **CLEANED** -- Stale duplicate was found and removed during validation
+
+If all hooks show PASS, announce: "All hooks validated successfully. No conflicts detected."
+
+If any hook shows FAIL or MISSING, announce the specific issues and provide the expected configuration for manual correction.
+
+---
+
+### Conflict Detection Logic
+
+The migration and validation steps work together to handle hook conflicts:
+
+```
+Wizard Execution
+  │
+  ├─ 1. Stale Hook Migration (pre-install)
+  │     └─ Scan settings files for prompt hooks matching Edit/Write/NotebookEdit
+  │     └─ Remove stale prompt hooks, preserve command hooks
+  │     └─ Log actions taken
+  │
+  ├─ 2. Project-Level Hook Installation (install)
+  │     └─ Install or update the command-based enforce_pipeline_scope.py hook
+  │
+  └─ 3. Post-Install Hook Validation (post-install)
+        └─ Validate all 8 expected hooks against installed hooks
+        └─ Detect any remaining duplicate matcher conflicts
+        └─ Clean up anything migration missed
+        └─ Output validation summary table
+```
+
+**Conflict identification**: A conflict exists when two hooks share the same event type and matcher pattern but have different hook types. The wizard resolves conflicts by removing the prompt-based hook and preserving the command-based hook, because command hooks provide deterministic, auditable behavior while prompt hooks are subject to AI interpretation variance.
+
+**Why command hooks take precedence**: Command hooks execute a Python script that reads configuration files and returns a structured decision. Prompt hooks ask the AI to interpret a natural language instruction, which can produce inconsistent results across sessions. The migration from prompt to command hooks (commit `0ef5070`) was specifically made to eliminate this variance.
+
+---
+
 ## Config File Format
 
 The wizard generates `.delivery/config.yml` as a pure YAML configuration file.


### PR DESCRIPTION
## Summary

- Setup wizard now detects and removes stale prompt-based PreToolUse hooks that conflict with `enforce_pipeline_scope.py` during config upgrade or fresh setup
- Post-install hook validation checks all 8 expected hooks (7 plugin + 1 project-level) with duplicate matcher detection and summary output
- Conflict detection logic documented with precedence rules (command > prompt)

Closes #67

## Changes

| File | Change |
|------|--------|
| `delivery-team/skills/delivery-flow/references/setup-wizard.md` | +173 lines: 3 new sections (Stale Hook Migration, Post-Install Hook Validation, Conflict Detection Logic) |
| `.delivery/config.yml` | Enable `github.create_pr` and `git.auto_branch` |
| `.delivery/memory/index.md` | Update run count and Dev stage health |
| `.delivery/memory/archive/run-2026-04-05-3d92.md` | Pipeline retrospective |

## Test plan

- [x] 15/15 acceptance criteria verified across 3 stories
- [x] 23/23 UAT test cases pass (migration, validation, documentation, cross-reference, dogfooding)
- [x] Expected hooks table verified against hooks.json (8/8 hooks match)
- [x] Existing wizard content preserved unchanged (0 deletions)
- [x] All DoD gates passed first-try (Idea, Plan, Dev, UAT)
- [ ] Run setup wizard on a test project to verify migration protocol end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)